### PR TITLE
Provision Postgres and Redis addons

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,14 +19,14 @@
 			"quantity": 1
 		}
 	},
+	"addons": [
+		"heroku-postgresql",
+		"heroku-redis"
+	],
 	"env": {
-		"DATABASE_URL": {
-			"description": "Database URL where you want to save the auth data",
-			"value": "data.db"
-		},
 		"DATABASE_TYPE": {
 			"description": "Database type which you want to connect with. Currently supports sqlite, mysql, postgres",
-			"value": "sqlite"
+			"value": "postgres"
 		},
 		"ADMIN_SECRET": {
 			"description": "Authorizer admin secret, used to access master data",
@@ -94,10 +94,6 @@
 		},
 		"GITHUB_CLIENT_SECRET": {
 			"description": "Github client secret for github login",
-			"required": false
-		},
-		"REDIS_URL": {
-			"description": "Redis URL used for persisting user session. If not configured session will be persisted in memory. Note: In memory sessions will not be persisted across server restart and not recommended for production",
 			"required": false
 		},
 		"DISABLE_EMAIL_VERIFICATION": {

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,9 +1,3 @@
-setup:
-  addons:
-    - plan: heroku-postgresql
-      as: DATABASE
-    - plan: heroku-redis
-      as: REDIS
 build:
   docker:
     web: Dockerfile

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,9 @@
+setup:
+  addons:
+    - plan: heroku-postgresql
+      as: DATABASE
+    - plan: heroku-redis
+      as: REDIS
 build:
   docker:
     web: Dockerfile


### PR DESCRIPTION
Due to the ephemeral nature of the Heroku apps memory and disk, it will be more useful to deploy them with Postgres and Redis addons from the beginning. Conveniently, the addons will provide correctly named environment variables `DATABASE_URL` and `REDIS_URL` 😊

You can test the proposed changes at URL: https://heroku.com/deploy?template=https://github.com/enstyled/authorizer-heroku/tree/patch-1