### PR TITLE
docker+app: surface April 2026 security hardening flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,14 @@ CMD ["./authorizer \\\n\
   --enable-graphql-introspection=\"${ENABLE_GRAPHQL_INTROSPECTION:-true}\" \\\n\
   --app-cookie-secure=\"${APP_COOKIE_SECURE:-true}\" \\\n\
   --admin-cookie-secure=\"${ADMIN_COOKIE_SECURE:-true}\" \\\n\
+  --trusted-proxies=\"${TRUSTED_PROXIES}\" \\\n\
+  --refresh-token-expires-in=\"${REFRESH_TOKEN_EXPIRES_IN:-2592000}\" \\\n\
+  --enable-hsts=\"${ENABLE_HSTS:-false}\" \\\n\
+  --disable-csp=\"${DISABLE_CSP:-false}\" \\\n\
+  --graphql-max-complexity=\"${GRAPHQL_MAX_COMPLEXITY:-300}\" \\\n\
+  --graphql-max-depth=\"${GRAPHQL_MAX_DEPTH:-15}\" \\\n\
+  --graphql-max-aliases=\"${GRAPHQL_MAX_ALIASES:-30}\" \\\n\
+  --graphql-max-body-bytes=\"${GRAPHQL_MAX_BODY_BYTES:-1048576}\" \\\n\
   --database-name=\"${DATABASE_NAME}\" \\\n\
   --database-username=\"${DATABASE_USERNAME}\" \\\n\
   --database-password=\"${DATABASE_PASSWORD}\" \\\n\

--- a/app.json
+++ b/app.json
@@ -45,9 +45,48 @@
 			"required": true
 		},
 		"ADMIN_SECRET": {
-			"description": "Secret for admin API access. Keep this secret and do not commit it.",
+			"description": "Secret for admin API access. Required, must be non-empty (the previous insecure 'password' default has been removed in the April 2026 security release).",
 			"generator": "secret",
 			"required": true
+		},
+		"TRUSTED_PROXIES": {
+			"description": "Comma-separated CIDRs of reverse proxies whose X-Forwarded-For will be honoured. Heroku routes traffic through their own router, so set this to the Heroku router CIDR or per-IP rate limiting will key on the router IP. See https://docs.authorizer.dev/core/security#trusted-proxies",
+			"required": false
+		},
+		"REFRESH_TOKEN_EXPIRES_IN": {
+			"description": "Refresh-token lifetime in seconds. Default 2592000 (30 days).",
+			"value": "2592000",
+			"required": false
+		},
+		"ENABLE_HSTS": {
+			"description": "Set to 'true' to emit Strict-Transport-Security. Heroku terminates TLS at the router so this is safe to enable.",
+			"value": "false",
+			"required": false
+		},
+		"DISABLE_CSP": {
+			"description": "Set to 'true' to disable the default Content-Security-Policy header. Escape hatch only.",
+			"value": "false",
+			"required": false
+		},
+		"GRAPHQL_MAX_COMPLEXITY": {
+			"description": "Max total complexity score per GraphQL operation.",
+			"value": "300",
+			"required": false
+		},
+		"GRAPHQL_MAX_DEPTH": {
+			"description": "Max nesting depth of a GraphQL selection set.",
+			"value": "15",
+			"required": false
+		},
+		"GRAPHQL_MAX_ALIASES": {
+			"description": "Max aliased fields per GraphQL operation (defends against alias amplification).",
+			"value": "30",
+			"required": false
+		},
+		"GRAPHQL_MAX_BODY_BYTES": {
+			"description": "Max GraphQL request body size in bytes. Default 1048576 (1 MiB).",
+			"value": "1048576",
+			"required": false
 		}
 	},
 	"stack": "container"


### PR DESCRIPTION
## Summary
Adds the new CLI flags from authorizerdev/authorizer PRs #582–#590 to both the Dockerfile and the Heroku \`app.json\` deploy form.

### Dockerfile
New CLI flags wired through the env-var → flag bridge:
- \`TRUSTED_PROXIES\` → \`--trusted-proxies\`
- \`REFRESH_TOKEN_EXPIRES_IN\` → \`--refresh-token-expires-in\`
- \`ENABLE_HSTS\` → \`--enable-hsts\`
- \`DISABLE_CSP\` → \`--disable-csp\`
- \`GRAPHQL_MAX_{COMPLEXITY,DEPTH,ALIASES,BODY_BYTES}\`

### app.json
- \`ADMIN_SECRET\` description now flags the breaking change (required, non-empty — the previous \`"password"\` default is gone)
- All seven new env vars declared with safe defaults so they appear in the Deploy-to-Heroku form
- \`TRUSTED_PROXIES\` carries a Heroku-specific note: Heroku routes traffic through their router, so this is required for accurate per-IP rate limiting
- \`ENABLE_HSTS\` note: Heroku terminates TLS at the router, so HSTS is safe to enable on Heroku

## Test plan
- [x] \`json.load(open('app.json'))\` validates
- [ ] Deploy-to-Heroku button shows the new env vars
- [ ] Deployed app starts cleanly with defaults