### PR TITLE
fix(deploy): repair crash-looping CLI flags, wire missing security flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Base runs as USER authorizer (uid 1000). For SQLite, ensure mounted /data is writable by that user.
-FROM quay.io/authorizer/authorizer:2.3.0
+# Pinned to the 2.4.0 release candidate because it is the first published
+# image with the current CLI flag surface (--url, --oauth2-1-strict,
+# --enable-org-discovery, --disable-totp-login/-webauthn-mfa/-email-otp/
+# -sms-otp/-mfa). Re-pin to the stable 2.4.0 tag once it ships.
+FROM quay.io/authorizer/authorizer:2.4.0-rc.7
 # Override so CMD runs in a shell and env vars (e.g. for Heroku) are expanded. See base image comment.
 # Use exec-form CMD with a single string so /bin/sh -c gets one argument; shell-form CMD can be split and drop into a shell.
 ENTRYPOINT ["/bin/sh", "-c"]
@@ -28,6 +32,7 @@ CMD ["exec ./authorizer \\\n\
   --allowed-origins=\"${ALLOWED_ORIGINS}\" \\\n\
   --default-authorize-response-type=\"${DEFAULT_AUTHORIZE_RESPONSE_TYPE}\" \\\n\
   --default-authorize-response-mode=\"${DEFAULT_AUTHORIZE_RESPONSE_MODE}\" \\\n\
+  --oauth2-1-strict=\"${OAUTH2_1_STRICT:-false}\" \\\n\
   --organization-name=\"${ORGANIZATION_NAME}\" \\\n\
   --organization-logo=\"${ORGANIZATION_LOGO}\" \\\n\
   --smtp-host=\"${SMTP_HOST}\" \\\n\
@@ -38,6 +43,7 @@ CMD ["exec ./authorizer \\\n\
   --smtp-sender-name=\"${SENDER_NAME}\" \\\n\
   --reset-password-url=\"${RESET_PASSWORD_URL}\" \\\n\
   --backchannel-logout-uri=\"${BACKCHANNEL_LOGOUT_URI}\" \\\n\
+  --url=\"${AUTHORIZER_URL}\" \\\n\
   --env=\"${ENV}\" \\\n\
   --host=\"${HOST:-0.0.0.0}\" \\\n\
   --metrics-port=\"${METRICS_PORT:-8081}\" \\\n\
@@ -51,6 +57,7 @@ CMD ["exec ./authorizer \\\n\
   --rate-limit-burst=\"${RATE_LIMIT_BURST:-20}\" \\\n\
   --rate-limit-fail-closed=\"${RATE_LIMIT_FAIL_CLOSED:-false}\" \\\n\
   --enable-login-page=\"${ENABLE_LOGIN_PAGE:-true}\" \\\n\
+  --enable-org-discovery=\"${ENABLE_ORG_DISCOVERY:-false}\" \\\n\
   --enable-playground=\"${ENABLE_PLAYGROUND:-true}\" \\\n\
   --disable-admin-header-auth=\"${DISABLE_ADMIN_HEADER_AUTH:-true}\" \\\n\
   --enable-graphql-introspection=\"${ENABLE_GRAPHQL_INTROSPECTION:-true}\" \\\n\
@@ -84,16 +91,17 @@ CMD ["exec ./authorizer \\\n\
   --smtp-local-name=\"${SMTP_LOCAL_NAME}\" \\\n\
   --smtp-skip-tls-verification=\"${SMTP_SKIP_TLS_VERIFICATION:-false}\" \\\n\
   --enable-strong-password=\"${ENABLE_STRONG_PASSWORD:-true}\" \\\n\
-  --enable-totp-login=\"${ENABLE_TOTP_LOGIN:-false}\" \\\n\
   --enable-basic-authentication=\"${ENABLE_BASIC_AUTHENTICATION:-true}\" \\\n\
   --enable-email-verification=\"${ENABLE_EMAIL_VERIFICATION:-false}\" \\\n\
   --enable-mobile-basic-authentication=\"${ENABLE_MOBILE_BASIC_AUTHENTICATION:-true}\" \\\n\
   --enable-phone-verification=\"${ENABLE_PHONE_VERIFICATION:-false}\" \\\n\
   --enable-magic-link-login=\"${ENABLE_MAGIC_LINK_LOGIN:-false}\" \\\n\
   --enforce-mfa=\"${ENFORCE_MFA:-true}\" \\\n\
-  --enable-mfa=\"${ENABLE_MFA:-false}\" \\\n\
-  --enable-email-otp=\"${ENABLE_EMAIL_OTP:-false}\" \\\n\
-  --enable-sms-otp=\"${ENABLE_SMS_OTP:-false}\" \\\n\
+  --disable-totp-login=\"${DISABLE_TOTP_LOGIN:-false}\" \\\n\
+  --disable-webauthn-mfa=\"${DISABLE_WEBAUTHN_MFA:-false}\" \\\n\
+  --disable-email-otp=\"${DISABLE_EMAIL_OTP:-false}\" \\\n\
+  --disable-sms-otp=\"${DISABLE_SMS_OTP:-false}\" \\\n\
+  --disable-mfa=\"${DISABLE_MFA:-false}\" \\\n\
   --enable-signup=\"${ENABLE_SIGNUP:-true}\" \\\n\
   --twilio-account-sid=\"${TWILIO_ACCOUNT_SID}\" \\\n\
   --twilio-api-key=\"${TWILIO_API_KEY}\" \\\n\

--- a/app.json
+++ b/app.json
@@ -49,6 +49,15 @@
 			"generator": "secret",
 			"required": true
 		},
+		"AUTHORIZER_URL": {
+			"description": "Canonical/trusted base URL of this deployment (e.g. https://your-app.herokuapp.com). When set, it is the only source used to build verification/reset/magic-link URLs, the JWT iss claim, and OIDC discovery URLs. Leaving it empty exposes host-header-injection account takeover (CWE-640) — set this once you know your Heroku app URL.",
+			"required": false
+		},
+		"OAUTH2_1_STRICT": {
+			"description": "Set to 'true' to enforce OAuth 2.1 restrictions (reject implicit/hybrid-with-token response types, require PKCE S256). Breaking; opt-in.",
+			"value": "false",
+			"required": false
+		},
 		"TRUSTED_PROXIES": {
 			"description": "Comma-separated CIDRs of reverse proxies whose X-Forwarded-For will be honoured. Heroku routes traffic through their own router, so set this to the Heroku router CIDR or per-IP rate limiting will key on the router IP. See https://docs.authorizer.dev/core/security#trusted-proxies",
 			"required": false


### PR DESCRIPTION
## Summary
- `--enable-totp-login`/`--enable-mfa`/`--enable-email-otp`/`--enable-sms-otp` don't exist in the authorizer binary; cobra rejects unknown flags and exits 1, so every Heroku deploy from this Dockerfile currently crash-loops on boot. Renamed to the current `--disable-totp-login`/`--disable-webauthn-mfa`/`--disable-email-otp`/`--disable-sms-otp`/`--disable-mfa` flags.
- Added `--url` (CWE-640 host-header-injection mitigation — was defined nowhere in this repo), `--oauth2-1-strict`, `--enable-org-discovery`. Surfaced `AUTHORIZER_URL` and `OAUTH2_1_STRICT` in `app.json`.
- Re-pinned the base image from `2.3.0` to `2.4.0-rc.7`: `2.3.0` predates the flag rename above and doesn't have the `--disable-*` flags either. Move to the stable `2.4.0` tag once it ships.

## Test plan
- [x] Built this Dockerfile against the real `quay.io/authorizer/authorizer:2.4.0-rc.7` image and confirmed the container boots and serves `/healthz` (previously exited 1 on the phantom flags)
- [ ] Deploy via the Heroku button and confirm dyno stays up